### PR TITLE
refat-tacometro

### DIFF
--- a/servidor/Tacometro.cpp
+++ b/servidor/Tacometro.cpp
@@ -34,7 +34,7 @@ int medirTempoEntreDoisPulsos()
   Servidor.ino deve impedir execução desta função
   para duracaoRotacao < 10 evitando retorno 0.1
 */
-float obterRpm( int duracaoRotacao )
+int obterRpm( int duracaoRotacao )
 {
   if ( duracaoRotacao > 10 )
   {

--- a/servidor/Tacometro.hpp
+++ b/servidor/Tacometro.hpp
@@ -6,7 +6,7 @@
 
 
 int medirTempoEntreDoisPulsos();
-float obterRpm( int duracaoRotacao );
+int obterRpm( int duracaoRotacao );
 float quilometroPorHora( const int PERIMETRO_CIRCULAR_PNEU, int rpm );
 
 #endif // TACOMETRO_HPP_INCLUDED

--- a/servidor/servidor.ino
+++ b/servidor/servidor.ino
@@ -34,10 +34,11 @@ bool oldDeviceConnected = false;
 
 //VARIÁVEIS ESPECIFICAS DO PROTOCOLO CYCLE
 uint8_t status = 0b00000000; //recursos
-uint16_t rpm = 0;
+uint16_t intervalo = 0;
+uint32_t contagemRotacoes = 0;
 uint16_t rumo = 0; // 0 até 360
 
-const uint8_t TAMANHO_MAX_MSG = 50;
+const uint8_t TAMANHO_MAX_MSG =37;
 
 /*Gere UUID's em: https://www.uuidgenerator.net */
 #define SERVICE_UUID        "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
@@ -113,15 +114,18 @@ void loop()
             int interval = medirTempoEntreDoisPulsos();
             if ( interval > 10 )
             {
-              rpm = interval;
+              contagemRotacoes++;
+              intervalo = interval;
             }
-            resposta.concat( "\"rpm\":" );
-            resposta.concat( obterRpm(rpm) );
-            resposta.concat( "," ); 
+            resposta.concat( "i:" );
+            resposta.concat( intervalo );
+            resposta.concat( ",c:" ); 
+            resposta.concat( contagemRotacoes );
+            resposta.concat( "," );
           }
         }
 
-        resposta.concat("\"pog\":1}");
+        resposta.concat("s:2}");
         
         if ( resposta.length() <= TAMANHO_MAX_MSG )
         {
@@ -130,7 +134,7 @@ void loop()
         }
         else
         {
-          caracteristica->setValue( (uint8_t*)"{\"stat\":120}", TAMANHO_MAX_MSG );
+          caracteristica->setValue( (uint8_t*)"{s:120}", TAMANHO_MAX_MSG );
           Serial.println("erro: mensagem maior que valor definido por macro TAMANHO_MAX_MSG !");
           caracteristica->notify();
         }


### PR DESCRIPTION
corrige erro grave onde servidor emitia dado computado de rpm. define mensagem Notificada como um pseudo json nao padrao menor. segundo campo de atributo c marca contagem de rotacoes foi adicionado.